### PR TITLE
Add link to deployed IG

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This provides a FHIR based representation of the base OpenEHR reference model.
 This is a technical artifact - it's not something intended for either FHIR or 
 openEHR developer consumption.
 
+This IG is hosted at https://build.fhir.org/ig/FHIR/openehr-base-ig/index.html
+
 ## FHIR Foundation Project Statement
 
 * Maintainers: Grahame Grieve (as FHIR Product Director) 


### PR DESCRIPTION
Seems useful for people trying it out. Or is there a standard url for finding an IG from a GitHub repo?